### PR TITLE
#Fix/login-bug

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -4,7 +4,7 @@ class UserSessionsController < ApplicationController
   end
 
   def create
-    @user_session = UserSession.new(user_session_params)
+    @user_session = UserSession.new(user_session_params.to_h)
     if @user_session.save
       flash[:success] = "Welcome back!"
       redirect_to root_path

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,6 +16,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:email, :username, :password)
+    params.require(:user).permit(:email, :username, :password, :password_confirmation)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,52 @@
 class User < ApplicationRecord
+  has_many :messages
+  has_many :conversations, :through => :participants
+
   acts_as_authentic do |c|
     c.crypto_provider = Authlogic::CryptoProviders::Sha512
   end
 
-  has_many :messages
-  has_many :conversations, :through => :participants
+  EMAIL = /
+    \A
+    [A-Z0-9_.&%+\-']+   # mailbox
+    @
+    (?:[A-Z0-9\-]+\.)+  # subdomains
+    (?:[A-Z]{2,25})     # TLD
+    \z
+  /ix
+  USERNAME = /\A[a-zA-Z0-9_][a-zA-Z0-9\.+\-_@ ]+\z/
+
+  validates :email,
+    format: {
+      with: EMAIL,
+      message: "should look like an email address."
+    },
+    length: { maximum: 100 },
+    uniqueness: {
+      case_sensitive: false,
+      if: :will_save_change_to_email?
+    }
+
+  validates :username,
+    format: {
+      with: USERNAME,
+      message: "should use only letters and numbers."
+    },
+    length: { within: 3..100 },
+    uniqueness: {
+      case_sensitive: false,
+      if: :will_save_change_to_username?
+    }
+
+  validates :password,
+    confirmation: { if: :require_password? },
+    length: {
+      minimum: 8,
+      if: :require_password?
+    }
+  validates :password_confirmation,
+    length: {
+      minimum: 8,
+      if: :require_password?
+  }
 end

--- a/db/migrate/20210218053621_add_index_to_users.rb
+++ b/db/migrate/20210218053621_add_index_to_users.rb
@@ -1,0 +1,5 @@
+class AddIndexToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_index :users, :username, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_17_204446) do
+ActiveRecord::Schema.define(version: 2021_02_18_053621) do
 
   create_table "conversations", force: :cascade do |t|
     t.string "status"
@@ -46,6 +46,8 @@ ActiveRecord::Schema.define(version: 2021_02_17_204446) do
     t.string "persistence_token"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
   add_foreign_key "messages", "conversations"


### PR DESCRIPTION
---
:warning: This pull request SHOULD NOT be merged, I created it just for further reference, main branch is working now :warning: 

--- 

There is a bug with the authlogic gem, it claims that the field 'email'
can be used as a valid option for signing in; 
![image](https://user-images.githubusercontent.com/31193448/108383797-b8f27b00-71cf-11eb-8c11-dc047fa55487.png)

but doing it this way, an error is thrown saying:
ActionView::Template::Error (undefined method `email' for #<UserSession: no credentials provided>):

Really hard to debug when official documentation affirms the opposite :rage: 
![image](https://user-images.githubusercontent.com/31193448/108312336-2a084300-717c-11eb-9fcd-c576fa640636.png)

Steps to reproduce the bug:
- Include email field and password as the two required fields for user authentication
- Run the rails server `bin/rails server`
- Go to sign_in page and try to authenticate a user
- The error should be there

It is worth mentioning that it works using username or login (along with the password) instead of email (that's the solution).

